### PR TITLE
Minor fixes

### DIFF
--- a/src/HLSLCrossCompilerContext.cpp
+++ b/src/HLSLCrossCompilerContext.cpp
@@ -66,18 +66,20 @@ void HLSLCrossCompilerContext::DoDataTypeAnalysis(ShaderPhase *psPhase)
 
 void HLSLCrossCompilerContext::ClearDependencyData()
 {
-
+	if (!psDependencies)
+		return;
 	switch (psShader->eShaderType)
 	{
 	case PIXEL_SHADER:
 	{
 		psDependencies->ClearCrossDependencyData();
+		break;
 	}
 	case HULL_SHADER:
 	{
 		psDependencies->eTessPartitioning = TESSELLATOR_PARTITIONING_UNDEFINED;
 		psDependencies->eTessOutPrim = TESSELLATOR_OUTPUT_UNDEFINED;
-						break;
+		break;
 	}
 	default:
 		break;

--- a/src/LoopTransform.cpp
+++ b/src/LoopTransform.cpp
@@ -28,15 +28,15 @@ namespace HLSLcc
 		using namespace std;
 		res.clear();
 
-		Instruction *i = &phase.psInst[0];
 		// A stack of loopinfo elements (stored in res)
 		list<LoopInfo *> loopStack;
 
 		// Storage for dummy LoopInfo elements to be used for switch-cases. We don't want them cluttering the Loops list so store them here.
 		list<LoopInfo> dummyLIForSwitches;
 
-		while (i != &*phase.psInst.end())
+		for (auto &inst : phase.psInst)
 		{
+			Instruction *i = &inst;
 			if (i->eOpcode == OPCODE_LOOP)
 			{
 				LoopInfo *currLoopInfo = &*res.insert(res.end(), LoopInfo());
@@ -75,7 +75,6 @@ namespace HLSLcc
 					li->m_ExitPoints.push_back(i);
 				}
 			}
-			i++;
 		}
 
 	}
@@ -347,6 +346,9 @@ namespace HLSLcc
 	{
 		Loops loops;
 		BuildLoopInfo(phase, loops);
+
+		if (!loops.size())
+			return;
 
 		std::for_each(loops.begin(), loops.end(), [&phase](LoopInfo &li)
 		{

--- a/src/Operand.cpp
+++ b/src/Operand.cpp
@@ -1,4 +1,4 @@
-
+#include <algorithm>
 #include "internal_includes/Operand.h"
 #include "internal_includes/debug.h"
 #include "internal_includes/HLSLccToolkit.h"

--- a/src/reflect.cpp
+++ b/src/reflect.cpp
@@ -402,7 +402,7 @@ static void ReadResources(const uint32_t* pui32Tokens,//in
 
 	psShaderInfo->psResourceBindings.clear();
 	psShaderInfo->psResourceBindings.resize(ui32NumResourceBindings);
-	psResBindings = &psShaderInfo->psResourceBindings[0];
+	psResBindings = !psShaderInfo->psResourceBindings.empty() ? &psShaderInfo->psResourceBindings[0] : nullptr;
 
     for(i=0; i < ui32NumResourceBindings; ++i)
     {
@@ -415,7 +415,7 @@ static void ReadResources(const uint32_t* pui32Tokens,//in
 
 	psShaderInfo->psConstantBuffers.clear();
 	psShaderInfo->psConstantBuffers.resize(ui32NumConstantBuffers);
-	psConstantBuffers = &psShaderInfo->psConstantBuffers[0];
+	psConstantBuffers = ui32NumConstantBuffers ? &psShaderInfo->psConstantBuffers[0] : nullptr;
 
     for(i=0; i < ui32NumConstantBuffers; ++i)
     {

--- a/src/toGLSLOperand.cpp
+++ b/src/toGLSLOperand.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "internal_includes/toGLSLOperand.h"
 #include "internal_includes/HLSLccToolkit.h"
 #include "internal_includes/HLSLCrossCompilerContext.h"

--- a/src/toMetalDeclaration.cpp
+++ b/src/toMetalDeclaration.cpp
@@ -1024,7 +1024,7 @@ void ToMetal::TranslateDeclaration(const Declaration* psDecl)
 		if (psContext->psShader->eShaderType == VERTEX_SHADER)
 		{
 			std::ostringstream oss;
-			uint32_t loc = psContext->psDependencies->GetVaryingLocation(name, VERTEX_SHADER, true);
+			uint32_t loc = psContext->psDependencies ? psContext->psDependencies->GetVaryingLocation(name, VERTEX_SHADER, true) : -1;
 			oss << "attribute(" << loc << ")";
 			semantic = oss.str();
 			psContext->m_Reflection.OnInputBinding(name, loc);

--- a/src/toMetalOperand.cpp
+++ b/src/toMetalOperand.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <stdio.h>
 #include "internal_includes/HLSLccToolkit.h"
 #include "internal_includes/HLSLCrossCompilerContext.h"


### PR DESCRIPTION
For some reason, when compiling some simple shaders (with no uniforms), psDependencies ends up null in a bunch of places.

Caught a missing break;.

In addition, there were some misuses of vector iterators, that MSVC's debug mode caught (you can't take the address of the first item of a zero length vector, for example).