### PR TITLE
Minor fixes for builiding on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(HLSLcc)
 
 option(HLSLCC_LIBRARY_SHARED "Build shared library instead of static." ON)
 
+if(MSVC)
+	add_definitions(-DNOMINMAX -DVC_EXTRALEAN -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS)
+endif(MSVC)
+
 set(HLSLCC_SRC
 		src/ControlFlowGraph.cpp
 		src/ControlFlowGraphUtils.cpp

--- a/src/Operand.cpp
+++ b/src/Operand.cpp
@@ -5,6 +5,7 @@
 #include "internal_includes/Shader.h"
 #include "internal_includes/HLSLCrossCompilerContext.h"
 #include "internal_includes/Instruction.h"
+#include <algorithm>
 
 uint32_t Operand::GetAccessMask() const
 {

--- a/src/toGLSLOperand.cpp
+++ b/src/toGLSLOperand.cpp
@@ -7,6 +7,7 @@
 #include "internal_includes/Shader.h"
 #include "internal_includes/toGLSL.h"
 #include <cmath>
+#include <algorithm>
 
 #include <sstream>
 

--- a/src/toMetalOperand.cpp
+++ b/src/toMetalOperand.cpp
@@ -5,6 +5,7 @@
 #include "internal_includes/debug.h"
 #include "internal_includes/Shader.h"
 #include "internal_includes/toMetal.h"
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 


### PR DESCRIPTION
Added include for algorithm since Visual Studio 2015 requires it for std::min/std::max. Added flags to disable MSVC's min/max macros and to prevent MSVC from pulling in unnecessary header files (may not have an immediate effect). Added compiler flags to silence scanf and deprecation warnings.  