### PR TITLE
fix issue with negation of (bool->int) result

### DIFF
--- a/src/toGLSLOperand.cpp
+++ b/src/toGLSLOperand.cpp
@@ -487,11 +487,19 @@ void ToGLSL::TranslateVariableNameWithMask(bstring glsl, const Operand* psOperan
 		{
 			if (CanDoDirectCast(eType, requestedType))
 			{
-				bformata(glsl, "%s(", GetConstructorForType(psContext, requestedType, requestedComponents, false));
-				numParenthesis++;
 				hasCtor = 1;
 				if (eType == SVT_BOOL)
+				{
 					needsBoolUpscale = 1;
+
+					// make sure to wrap the whole thing in parens so the upscale
+					// multiply only applies to the bool
+					bcatcstr(glsl, "(");
+					numParenthesis++;
+				}
+
+				bformata(glsl, "%s(", GetConstructorForType(psContext, requestedType, requestedComponents, false));
+				numParenthesis++;
 			}
 			else
 			{
@@ -1431,6 +1439,9 @@ void ToGLSL::TranslateVariableNameWithMask(bstring glsl, const Operand* psOperan
 			bcatcstr(glsl, ") * 0xffffffffu");
 		else
 			bcatcstr(glsl, ") * int(0xffffffffu)");
+		numParenthesis--;
+
+		bcatcstr(glsl, ")");
 		numParenthesis--;
 	}
 

--- a/src/toMetalOperand.cpp
+++ b/src/toMetalOperand.cpp
@@ -389,11 +389,19 @@ std::string ToMetal::TranslateVariableName(const Operand* psOperand, uint32_t ui
 		{
 			if (CanDoDirectCast(eType, requestedType))
 			{
-				oss << GetConstructorForType(psContext, requestedType, requestedComponents, false) << "(";
-				numParenthesis++;
 				hasCtor = 1;
 				if (eType == SVT_BOOL)
+				{
 					needsBoolUpscale = 1;
+
+					// make sure to wrap the whole thing in parens so the upscale
+					// multiply only applies to the bool
+					oss << "(";
+					numParenthesis++;
+				}
+
+				oss << GetConstructorForType(psContext, requestedType, requestedComponents, false) << "(";
+				numParenthesis++;
 			}
 			else
 			{
@@ -1048,6 +1056,9 @@ std::string ToMetal::TranslateVariableName(const Operand* psOperand, uint32_t ui
 			oss << ") * 0xffffffffu";
 		else
 			oss << ") * int(0xffffffffu)";
+		numParenthesis--;
+
+		oss << ")";
 		numParenthesis--;
 	}
 


### PR DESCRIPTION
An `OPCODE_NOT` followed by a `SVT_BOOL`->`SVT_INT` conversion can result in the following when the `needsBoolUpscale` block is hit:

```
bool myBool = false;
int result = ~(myBool) * int(0xffffffffu);
```

This PR emits the correct GLSL, wrapping the upscale operation in parentheses:

```
int result = ~((myBool) * int(0xffffffffu));
```

It applies the same fix to generated Metal Shading Language.