### PR TITLE
explicit byte offsets for UBO members, using ARB_enhanced_layouts

### DIFF
--- a/include/hlslcc.h
+++ b/include/hlslcc.h
@@ -453,6 +453,10 @@ static const unsigned int HLSLCC_FLAG_VULKAN_SPECIALIZATION_CONSTANTS = 0x200000
 // If set, this shader uses the GLSL extension EXT_shader_framebuffer_fetch
 static const unsigned int HLSLCC_FLAG_SHADER_FRAMEBUFFER_FETCH = 0x400000;
 
+// If set, UBO members get explicit offset locations to match HLSL offsets.
+// Requires ARB_enhanced_layouts
+static const unsigned int HLSLCC_FLAG_UBO_MEMBER_OFFSETS = 0x800000;
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/toGLSL.cpp
+++ b/src/toGLSL.cpp
@@ -278,6 +278,9 @@ static void AddVersionDependentCode(HLSLCrossCompilerContext* psContext)
 		bcatcstr(glsl, "precision highp int;\n");
 	}
 
+	if (psContext->flags & HLSLCC_FLAG_UBO_MEMBER_OFFSETS)
+		bcatcstr(extensions,"#extension GL_ARB_enhanced_layouts : require\n");
+
 	if(psContext->psShader->eShaderType == PIXEL_SHADER && psContext->psShader->eTargetLanguage >= LANG_150)
 	{
 		if(psContext->flags & HLSLCC_FLAG_ORIGIN_UPPER_LEFT)

--- a/src/toGLSLDeclaration.cpp
+++ b/src/toGLSLDeclaration.cpp
@@ -869,6 +869,9 @@ static void DeclareUBOConstants(HLSLCrossCompilerContext* psContext, const uint3
 	{
 		if(skipUnused && !psCBuf->asVars[i].sType.m_IsUsed)
 			continue;
+
+		if (psContext->flags & HLSLCC_FLAG_UBO_MEMBER_OFFSETS)
+			bformata(glsl, "\tlayout(offset=%d) ", psCBuf->asVars[i].ui32StartOffset);
 		
 		DeclareConstBufferShaderVariable(psContext,
 			psCBuf->asVars[i].name.c_str(),


### PR DESCRIPTION
This new flag employs `ARB_enhanced_layouts` to allow explicit byte offsets for UBO struct members.  This can make it possible to rely on identical memory layouts across HLSL and GLSL instead of one of the packing qualifiers.