### PR TITLE
Updated to support basic parsing of resources for Shader Model 5.1

### DIFF
--- a/include/ShaderInfo.h
+++ b/include/ShaderInfo.h
@@ -229,6 +229,7 @@ struct ResourceBinding
 	uint32_t ui32BindCount;
 	uint32_t ui32Space;
 	uint32_t ui32Flags;
+	uint32_t ui32RangeID;
 	REFLECT_RESOURCE_DIMENSION eDimension;
 	RESOURCE_RETURN_TYPE ui32ReturnType;
 	uint32_t ui32NumSamples;

--- a/include/ShaderInfo.h
+++ b/include/ShaderInfo.h
@@ -227,6 +227,7 @@ struct ResourceBinding
 	ResourceType eType;
 	uint32_t ui32BindPoint;
 	uint32_t ui32BindCount;
+	uint32_t ui32Space;
 	uint32_t ui32Flags;
 	REFLECT_RESOURCE_DIMENSION eDimension;
 	RESOURCE_RETURN_TYPE ui32ReturnType;

--- a/src/reflect.cpp
+++ b/src/reflect.cpp
@@ -203,17 +203,15 @@ static const uint32_t* ReadResourceBinding(ShaderInfo* psShaderInfo, const uint3
     psBinding->eType = (ResourceType)*pui32Tokens++;
     psBinding->ui32ReturnType = (RESOURCE_RETURN_TYPE)*pui32Tokens++;
     psBinding->eDimension = (REFLECT_RESOURCE_DIMENSION)*pui32Tokens++;
-    psBinding->ui32NumSamples = *pui32Tokens++;
+    psBinding->ui32NumSamples = *pui32Tokens++; // fxc generates 2^32 - 1 for non MS images
     psBinding->ui32BindPoint = *pui32Tokens++;
     psBinding->ui32BindCount = *pui32Tokens++;
     psBinding->ui32Flags = *pui32Tokens++;
     if (((psShaderInfo->ui32MajorVersion >= 5) && (psShaderInfo->ui32MinorVersion >= 1)) ||
         (psShaderInfo->ui32MajorVersion > 5)) 
     {
-        // SM51 has spaces
         psBinding->ui32Space = *pui32Tokens++;
-        // Unsure what this field is
-        pui32Tokens++;
+        psBinding->ui32RangeID = *pui32Tokens++;
     }
 	psBinding->ePrecision = REFLECT_RESOURCE_PRECISION_UNKNOWN;
 

--- a/src/reflect.cpp
+++ b/src/reflect.cpp
@@ -193,7 +193,7 @@ static void ReadPatchConstantSignatures(const uint32_t* pui32Tokens,
     }
 }
 
-static const uint32_t* ReadResourceBinding(const uint32_t* pui32FirstResourceToken, const uint32_t* pui32Tokens, ResourceBinding* psBinding, uint32_t decodeFlags)
+static const uint32_t* ReadResourceBinding(ShaderInfo* psShaderInfo, const uint32_t* pui32FirstResourceToken, const uint32_t* pui32Tokens, ResourceBinding* psBinding, uint32_t decodeFlags)
 {
     uint32_t ui32NameOffset = *pui32Tokens++;
 
@@ -207,6 +207,14 @@ static const uint32_t* ReadResourceBinding(const uint32_t* pui32FirstResourceTok
     psBinding->ui32BindPoint = *pui32Tokens++;
     psBinding->ui32BindCount = *pui32Tokens++;
     psBinding->ui32Flags = *pui32Tokens++;
+    if (((psShaderInfo->ui32MajorVersion >= 5) && (psShaderInfo->ui32MinorVersion >= 1)) ||
+        (psShaderInfo->ui32MajorVersion > 5)) 
+    {
+        // SM51 has spaces
+        psBinding->ui32Space = *pui32Tokens++;
+        // Unsure what this field is
+        pui32Tokens++;
+    }
 	psBinding->ePrecision = REFLECT_RESOURCE_PRECISION_UNKNOWN;
 
 	if (decodeFlags & HLSLCC_FLAG_SAMPLER_PRECISION_ENCODED_IN_NAME)
@@ -408,7 +416,7 @@ static void ReadResources(const uint32_t* pui32Tokens,//in
 
     for(i=0; i < ui32NumResourceBindings; ++i)
     {
-        pui32ResourceBindings = ReadResourceBinding(pui32FirstToken, pui32ResourceBindings, psResBindings+i, decodeFlags);
+        pui32ResourceBindings = ReadResourceBinding(psShaderInfo, pui32FirstToken, pui32ResourceBindings, psResBindings+i, decodeFlags);
 		ASSERT(psResBindings[i].ui32BindPoint < MAX_RESOURCE_BINDINGS);
 	}
 


### PR DESCRIPTION
The stride size for a Shader Model 5.1 is 40 bytes and not 32 bytes like 5.0 and older. Seems like the fields before space remain the same. Just added two additional reads from the tokens. Not sure what the second uint32 does, but the first one is for the space. 